### PR TITLE
refactor: move supported locales to constants.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,3 +10,4 @@ export * from "./src/esim";
 export * from "./src/api";
 export * from "./src/payment";
 export * from "./src/apiLogs";
+export * from "./src/constants";

--- a/src/booking.d.ts
+++ b/src/booking.d.ts
@@ -4,8 +4,9 @@ import { User } from "./user";
 import { Partner } from "./partner";
 import { PromoCode } from "./promoCode";
 import { SentMessages } from "./message";
-import { HubbyModel, SupportedLocales } from "./hubby";
+import { HubbyModel } from "./hubby";
 import { PackageSpecifications } from "./api";
+import { SupportedLocales } from "./constants";
 
 //Status explanation
 //PENDING: Booking is pending and waiting for payment

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,21 @@
+export const SUPPORTED_LOCALES = [
+    'en-US', 
+    'en-GB', 
+    'nl-NL', 
+    'de-DE', 
+    'fr-FR', 
+    'it-IT', 
+    'es-ES', 
+    'cs-CZ', 
+    'pl-PL', 
+    'pt-PT',
+    'fr-BE', 
+    'nl-BE', 
+    'de-AT', 
+    'de-CH', 
+    'fr-CH', 
+    'it-CH', 
+    'de-BE'
+] as const;
+
+export type SupportedLocales = typeof SUPPORTED_LOCALES[number]; 

--- a/src/hubby.d.ts
+++ b/src/hubby.d.ts
@@ -7,6 +7,3 @@ export type HubbyModel = {
     created_by: string | null | DocumentReference
     updated_by: string | null | DocumentReference
 }
-
-export const supportedLocales: readonly ["en-US", "en-GB", "nl-NL", "de-DE", "fr-FR", "it-IT", "es-ES", "cs-CZ", "pl-PL", "pt-PT", "fr-BE", "nl-BE", "de-AT", "de-CH", "fr-CH", "it-CH", "de-BE"]
-export type SupportedLocales = (typeof supportedLocales)[number];

--- a/src/partner.d.ts
+++ b/src/partner.d.ts
@@ -1,6 +1,6 @@
 import { DocumentReference, Timestamp } from 'firebase-admin/firestore'
-import { HubbyModel, SupportedLocales } from './hubby';
-import { Booking } from './booking';
+import { HubbyModel } from './hubby';
+import type { SupportedLocales } from './constants';
 
 export type Partner = {
     administration_fee: number | null;


### PR DESCRIPTION
- Create new constants.ts file with SUPPORTED_LOCALES array and type
- Remove supportedLocales from hubby.d.ts to avoid duplication
- Update imports in partner.d.ts and booking.d.ts to use new location
- Export constants from package root index.d.ts